### PR TITLE
Add support for CMYK text

### DIFF
--- a/src/main/java/com/itextpdf/awt/PdfGraphics2D.java
+++ b/src/main/java/com/itextpdf/awt/PdfGraphics2D.java
@@ -107,7 +107,6 @@ import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.ByteBuffer;
 import com.itextpdf.text.pdf.CMYKColor;
-import com.itextpdf.text.pdf.ExtendedColor;
 import com.itextpdf.text.pdf.PdfAction;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfGState;

--- a/src/main/java/com/itextpdf/awt/PdfGraphics2D.java
+++ b/src/main/java/com/itextpdf/awt/PdfGraphics2D.java
@@ -66,6 +66,7 @@ import java.awt.Stroke;
 import java.awt.TexturePaint;
 import java.awt.Transparency;
 import java.awt.RenderingHints.Key;
+import java.awt.color.ColorSpace;
 import java.awt.font.FontRenderContext;
 import java.awt.font.GlyphVector;
 import java.awt.font.TextAttribute;
@@ -105,6 +106,8 @@ import com.itextpdf.awt.geom.PolylineShape;
 import com.itextpdf.text.BaseColor;
 import com.itextpdf.text.pdf.BaseFont;
 import com.itextpdf.text.pdf.ByteBuffer;
+import com.itextpdf.text.pdf.CMYKColor;
+import com.itextpdf.text.pdf.ExtendedColor;
 import com.itextpdf.text.pdf.PdfAction;
 import com.itextpdf.text.pdf.PdfContentByte;
 import com.itextpdf.text.pdf.PdfGState;
@@ -498,7 +501,7 @@ public class PdfGraphics2D extends Graphics2D {
                             }
                             cb.setGState(gs);
                         }
-                        cb.setColorStroke(new BaseColor(color.getRGB()));
+                        cb.setColorStroke(prepareColor(color));
                         restoreTextRenderingMode = true;
                     }
                 }
@@ -1666,6 +1669,15 @@ public class PdfGraphics2D extends Graphics2D {
         }
     }
 
+    public static BaseColor prepareColor(Color color) {
+        if (color.getColorSpace().getType() == ColorSpace.TYPE_CMYK) {
+           float[] comp = color.getColorComponents(null);
+           return new CMYKColor(comp[0], comp[1], comp[2], comp[3]);
+        } else {
+           return new BaseColor(color.getRGB());
+        }
+    }
+
     private void setPaint(boolean invert, double xoffset, double yoffset, boolean fill) {
         if (paint instanceof Color) {
             Color color = (Color)paint;
@@ -1681,7 +1693,7 @@ public class PdfGraphics2D extends Graphics2D {
                     }
                     cb.setGState(gs);
                 }
-                cb.setColorFill(new BaseColor(color.getRGB()));
+                cb.setColorFill(prepareColor(color));
             }
             else {
                 if (alpha != currentStrokeGState) {
@@ -1694,7 +1706,7 @@ public class PdfGraphics2D extends Graphics2D {
                     }
                     cb.setGState(gs);
                 }
-                cb.setColorStroke(new BaseColor(color.getRGB()));
+                cb.setColorStroke(prepareColor(color));
             }
         }
         else if (paint instanceof GradientPaint) {


### PR DESCRIPTION
Without this change all texts added using PDFGraphics2D are converted to RGB. As result it isn't possible to create valid PDF/X-1a document.