### PR TITLE
close file handles when done

### DIFF
--- a/itext/src/main/java/com/itextpdf/text/pdf/TrueTypeFont.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/TrueTypeFont.java
@@ -855,11 +855,8 @@ class TrueTypeFont extends BaseFont {
                 readBbox();
             }
         } finally {
-            //TODO: For embedded fonts, the underlying data source for the font will be left open until this TrueTypeFont object is collected by the Garbage Collector.  That may not be optimal.
-            if (!embedded) {
                 rf.close();
                 rf = null;
-            }
         }
     }
 


### PR DESCRIPTION
Overview of the Issue - Getting an embedded font with the FontFactory causes a file handle leak.

Motivation for or Use Case - Embedding fonts are useful to ensure that multi-lingual end-users always have the correct font available for the PDF produced. When a web service generates thousands of PDFs with embedded fonts the system ends up grinding to a halt when no more file handles are available.

Regression - No

Operating System - Reproduced in OS X 10.10.5, and CentOS 6.6. Did not test under Windows.

Reproduce the Error - Please see ITextFileLeak.zip

reference - http://stackoverflow.com/questions/34664066/itext-getfont-file-handle-leak