### PR TITLE
OCGParser is not thread-safe

### DIFF
--- a/xtra/src/main/java/com/itextpdf/text/pdf/ocg/OCGParser.java
+++ b/xtra/src/main/java/com/itextpdf/text/pdf/ocg/OCGParser.java
@@ -73,10 +73,15 @@ public class OCGParser {
     public static final String DEFAULTOPERATOR = "DefaultOperator";
     
 	/** A map with all supported operators operators (PDF syntax). */
-    protected static Map<String, PdfOperator> operators = null;
+    protected static final Map<String, PdfOperator> operators;
+
+	static {
+		operators = new HashMap<String, PdfOperator>();
+		populateOperators();
+	}
     
     /** The OutputStream of this worker object. */
-    protected static ByteArrayOutputStream baos;
+    protected ByteArrayOutputStream baos;
    
     /** Keeps track of BMC/EMC balance. */
     protected int mc_balance = 0;
@@ -95,7 +100,6 @@ public class OCGParser {
      * @param ocgs	a set of String values with the names of the OCGs that need to be removed.
      */
     public OCGParser(Set<String> ocgs) {
-    	populateOperators();
     	this.ocgs = ocgs;
     }
     
@@ -164,10 +168,7 @@ public class OCGParser {
     /**
      * Populates the operators variable.
      */
-    protected void populateOperators() {
-    	if (operators != null)
-    		return;
-    	operators = new HashMap<String, PdfOperator>();
+    protected static void populateOperators() {
     	operators.put(DEFAULTOPERATOR, new CopyContentOperator());
     	PathConstructionOrPaintingOperator opConstructionPainting = new PathConstructionOrPaintingOperator();
     	operators.put("m", opConstructionPainting);


### PR DESCRIPTION
Greetings,

we place image stamps on pdf documents in the following manner (the idea is: if documents comes through stamping engine twice we remove previous stamps):

```
String stampLayerName = "uniqueString";
PdfReader reader = new PdfReader(inputStream);
PdfStamper stamper = new PdfStamper(reader, outputStream);
new OCGRemover().removeLayers(reader, stampLayerName);
stamper.close();

...

PdfReader reader = new PdfReader(inputStream);
PdfStamper stamper = new PdfStamper(reader, outputStream);
PdfLayer stampLayer = new PdfLayer(stampLayerName, stamper.getWriter());
stampLayer.setOnPanel(true);
stampLayer.setPrint("print", true);
stampLayer.setOn(true);
stampLayer.setView(true);
int lastPage = 1;
if (stamp.isAllPages()) {
	lastPage = reader.getNumberOfPages();
}
for (int i = 1; i <= lastPage; i++) {
	PdfContentByte overContent = stamper.getOverContent(i);
	Rectangle mediabox = reader.getPageSizeWithRotation(i);
	Image image = PdfUtil.createImage(stamp, mediabox, isRescaleProducer(reader));
	overContent.beginLayer(stampLayer);
	overContent.addImage(image);
	overContent.endLayer();
}
stamper.close();
```

The problem is sometimes we get broken resulting PDFs, i.e. the size of file is near the expected value, but acrobat, pdf.js and other viewers do not display resulting PDF properly, typical issues are: blank pages and not all stamps are displayed. I suspect that we are facing with thread-safety issues in OCGParser.