### PR TITLE
Remove incompatible @Override annotation

### DIFF
--- a/itext/src/test/java/com/itextpdf/text/pdf/table/TableEventTest.java
+++ b/itext/src/test/java/com/itextpdf/text/pdf/table/TableEventTest.java
@@ -59,7 +59,6 @@ public class TableEventTest {
 
     private static class DummyEvent implements PdfPTableEvent {
 
-        @Override
         public void tableLayout(PdfPTable table, float[][] widths, float[] heights, int headerRows, int rowStart, PdfContentByte[] canvases) {
         }
     }


### PR DESCRIPTION
The @Override annotation added in #22 is imcompatible with Java version 1.5 as specified in the pom.xml. @Override annotations on implemented interface methods are allowed from Java 1.6 upwards, only. Alternatively, raise the specified Java version to 1.6.