### PR TITLE
Fix memory leak when parsing PDF files with lots of xobjects

### DIFF
--- a/itext/src/main/java/com/itextpdf/text/pdf/parser/PdfContentStreamProcessor.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/parser/PdfContentStreamProcessor.java
@@ -71,6 +71,7 @@ import com.itextpdf.text.pdf.PdfLiteral;
 import com.itextpdf.text.pdf.PdfName;
 import com.itextpdf.text.pdf.PdfNumber;
 import com.itextpdf.text.pdf.PdfObject;
+import com.itextpdf.text.pdf.PdfReader;
 import com.itextpdf.text.pdf.PdfStream;
 import com.itextpdf.text.pdf.PdfString;
 import com.itextpdf.text.pdf.RandomAccessFileOrArray;
@@ -364,7 +365,7 @@ public class PdfContentStreamProcessor {
      */
     private void displayXObject(PdfName xobjectName) throws IOException {
         PdfDictionary xobjects = resources.getAsDict(PdfName.XOBJECT);
-        PdfObject xobject = xobjects.getDirectObject(xobjectName);
+        PdfObject xobject = PdfReader.getPdfObjectRelease(xobjects.get(xobjectName));
         PdfStream xobjectStream = (PdfStream)xobject;
 
         PdfName subType = xobjectStream.getAsName(PdfName.SUBTYPE);


### PR DESCRIPTION
The parser was calling getObject(), which resulted in the object being added to the xrefobjs cache.  For large PDF files, this could cause excessive memory usage.  It's not the kind of thing that really lends itself to unit testing - not sure what else ya'll need to accept the change, please let me know!