### PR TITLE
Bug in BBox translation when flattening annotations

### DIFF
--- a/itext/pom.xml
+++ b/itext/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>itextpdf</artifactId>
-  <version>5.5.12</version>
+  <version>5.5.12-TB</version>
 
   <name>iText Core</name>
   <description>A Free Java-PDF library</description>

--- a/itext/src/main/java/com/itextpdf/text/Version.java
+++ b/itext/src/main/java/com/itextpdf/text/Version.java
@@ -70,7 +70,7 @@ public final class Version {
 	 * This String contains the version number of this iText release.
 	 * For debugging purposes, we request you NOT to change this constant.
 	 */
-	private String release = "5.5.12";
+	private String release = "5.5.12-TB";
 	/**
 	 * This String contains the iText version as shown in the producer line.
 	 * iText is a product developed by iText Group NV.

--- a/itext/src/main/java/com/itextpdf/text/pdf/PdfStamperImp.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/PdfStamperImp.java
@@ -1307,7 +1307,7 @@ class PdfStamperImp extends PdfWriter {
                                 }
                             }
                         } else {
-                            if ( PdfName.FREETEXT.equals(subType) ) {
+                            if ( PdfName.FREETEXT.equals(subType)) {
                                 final PdfString defaultAppearancePdfString = annDic.getAsString(PdfName.DA);
                                 if (defaultAppearancePdfString != null) {
                                     final PdfString freeTextContent = annDic.getAsString(PdfName.CONTENTS);
@@ -1384,11 +1384,11 @@ class PdfStamperImp extends PdfWriter {
                                 !Arrays.equals(DEFAULT_MATRIX, objDict.getAsArray(PdfName.MATRIX).asDoubleArray())) {
                             double[] matrix = objDict.getAsArray(PdfName.MATRIX).asDoubleArray();
                             Rectangle transformBBox = transformBBoxByMatrix(bBox, matrix);
-                            cb.addTemplate(app, (rect.getWidth() / transformBBox.getWidth()), 0, 0, (rect.getHeight() / transformBBox.getHeight()), rect.getLeft(), rect.getBottom());
+                            cb.addTemplate(app, (rect.getWidth() / transformBBox.getWidth()), 0, 0, (rect.getHeight() / transformBBox.getHeight()), rect.getLeft() - transformBBox.getLeft(), rect.getBottom() - transformBBox.getBottom());
                         } else {
                             //Changed so that when the annotation has a difference scale than the xObject in the appearance dictionary, the image is consistent between
                             //the input and the flattened document.  When the annotation is rotated or skewed, it will still be flattened incorrectly.
-                            cb.addTemplate(app, (rect.getWidth() / bBox.getWidth()), 0, 0, (rect.getHeight() / bBox.getHeight()), rect.getLeft(), rect.getBottom());
+                            cb.addTemplate(app, (rect.getWidth() / bBox.getWidth()), 0, 0, (rect.getHeight() / bBox.getHeight()), rect.getLeft() - bBox.getLeft(), rect.getBottom() - bBox.getBottom());
                         }
                         cb.setLiteral("q ");
 

--- a/pdfa/pom.xml
+++ b/pdfa/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>itext-pdfa</artifactId>
-  <version>5.5.12</version>
+  <version>5.5.12-TB</version>
 
   <name>iText PDF/A</name>
   <description>iText ISO-19005 Module</description>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
 
   <artifactId>root</artifactId>
-  <version>5.5.12</version>
+  <version>5.5.12-TB</version>
   <packaging>pom</packaging>
 
   <name>iText</name>

--- a/xmlworker/pom.xml
+++ b/xmlworker/pom.xml
@@ -11,7 +11,7 @@
 
   <groupId>com.itextpdf.tool</groupId>
   <artifactId>xmlworker</artifactId>
-  <version>5.5.12</version>
+  <version>5.5.12-TB</version>
 
   <name>iText XML Worker</name>
   <description>Parses XML to PDF, with CSS support, using iText</description>

--- a/xtra/pom.xml
+++ b/xtra/pom.xml
@@ -10,7 +10,7 @@
   </parent>
 
   <artifactId>itext-xtra</artifactId>
-  <version>5.5.12</version>
+  <version>5.5.12-TB</version>
 
   <name>iText Xtra</name>
   <description>iText Xtra, part of iText a Free Java-PDF library</description>


### PR DESCRIPTION
Hi,
I ran into a problem with flattening callout annotations done through Foxit. After being flattened into a PDF via PdfStamper, their position was somewhat "off". I'm not a PDF expert at all, but having dug into PdfStamperImp.flattenAnnotations(boolean) method, it is considering the BBox translation only for scale of the PDF Object, but not for its position. 
The attached pull request works for me and makes logical sense, but not an expert for PDFs.

Thanks,
Thomas
