### PR TITLE
change CrlClientOnline to ignore content-type

### DIFF
--- a/itext/src/main/java/com/itextpdf/text/pdf/security/CrlClientOnline.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/security/CrlClientOnline.java
@@ -173,7 +173,7 @@ public class CrlClientOnline implements CrlClient {
         			throw new IOException(MessageLocalization.getComposedMessage("invalid.http.response.1", con.getResponseCode()));
         		}
         		//Get Response
-        		InputStream inp = (InputStream) con.getContent();
+        		InputStream inp = con.getInputStream();
         		byte[] buf = new byte[1024];
         		ByteArrayOutputStream bout = new ByteArrayOutputStream();
         		while (true) {


### PR DESCRIPTION
Using CrlClientOnline to fetch CRLs fails if the webserver publishing the CRL does not provide a content-type header in the response. Since the response is basically just converted to an input stream and is used in its raw format, the content type is not really needed. The case where I've seen this break is while fetching the CRL from Adobe CDS: http://crl.adobe.com/cds.crl