### PR TITLE
Update CRLVerifier.java

### DIFF
--- a/itext/src/main/java/com/itextpdf/text/pdf/security/CRLVerifier.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/security/CRLVerifier.java
@@ -133,7 +133,7 @@ public class CRLVerifier extends RootStoreVerifier {
 			return false;
 		// We only check CRLs valid on the signing date for which the issuer matches
 		if (crl.getIssuerX500Principal().equals(signCert.getIssuerX500Principal())
-			&& signDate.after(crl.getThisUpdate()) && signDate.before(crl.getNextUpdate())) {
+			&& (signDate.before(crl.getThisUpdate()) || signDate.before(crl.getNextUpdate()))) {
 			// the signing certificate may not be revoked
 			if (isSignatureValid(crl, issuerCert) && crl.isRevoked(signCert)) {
 				throw new VerificationException(signCert, "The certificate has been revoked.");


### PR DESCRIPTION
It is wrong to ask the signdate must be after the thisUpdate time of crl. For example,  one pdf was signed in 2018-08-27 and the cert didn't be revoked.  The CA update crl daily, so the thisUpdate time is 2018-08-28 and nextUpdate time is 2018-08-29.   If I verify the pdf in 2018-08-28 and the cert isn't in the crl, it should be return the good status when check the revocation status of the cert.