### PR TITLE
fix ArithmeticException

### DIFF
--- a/itext/src/main/java/com/itextpdf/text/pdf/crypto/ARCFOUREncryption.java
+++ b/itext/src/main/java/com/itextpdf/text/pdf/crypto/ARCFOUREncryption.java
@@ -57,19 +57,21 @@ public class ARCFOUREncryption {
     }
 
     public void prepareARCFOURKey(byte key[], int off, int len) {
-        int index1 = 0;
-        int index2 = 0;
-        for (int k = 0; k < 256; ++k)
-            state[k] = (byte)k;
-        x = 0;
-        y = 0;
-        byte tmp;
-        for (int k = 0; k < 256; ++k) {
-            index2 = (key[index1 + off] + state[k] + index2) & 255;
-            tmp = state[k];
-            state[k] = state[index2];
-            state[index2] = tmp;
-            index1 = (index1 + 1) % len;
+        if (len != 0) {
+            int index1 = 0;
+            int index2 = 0;
+            for (int k = 0; k < 256; ++k)
+                state[k] = (byte)k;
+            x = 0;
+            y = 0;
+            byte tmp;
+            for (int k = 0; k < 256; ++k) {
+                index2 = (key[index1 + off] + state[k] + index2) & 255;
+                tmp = state[k];
+                state[k] = state[index2];
+                state[index2] = tmp;
+                index1 = (index1 + 1) % len;
+            }
         }
     }
 


### PR DESCRIPTION
in method com.itextpdf.text.pdf.crypto.ARCFOUREncryption.prepareARCFOURKey 
[![image](https://user-images.githubusercontent.com/44200574/137727300-d7be248a-cd34-44de-b0a6-39351b7ff439.png)
](url)
The parameter len is used as a divisor, but it is not judged in advance whether it is zero, and it is likely to hit ArithmeticException
